### PR TITLE
LoadBalancer multiple providers enabled in plugin

### DIFF
--- a/neutron_plugin_contrail/plugins/opencontrail/loadbalancer/plugin.py
+++ b/neutron_plugin_contrail/plugins/opencontrail/loadbalancer/plugin.py
@@ -4,7 +4,7 @@
 from loadbalancer_db import LoadBalancerPluginDb
 
 class LoadBalancerPlugin(LoadBalancerPluginDb):
-    supported_extension_aliases = ["lbaas"]
+    supported_extension_aliases = ["lbaas", "service-type"]
 
     def __init__(self):
         super(LoadBalancerPlugin, self).__init__()


### PR DESCRIPTION
Chanegs in plugin.py enable support of ServiceProviders by plugin.
Changes in loadbalancer_db.py register providers from configuration as ServiceApplianceSets that are used later by svc_monitor.
